### PR TITLE
Add normalization pipeline with coref/temporal resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ module = [
     "stanza.*",
     "transformers.*",
     "torch.*",
+    "dateparser.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,11 @@ rerank_flashrank = [
     "flashrank>=0.2.0"
 ]
 
+# Content normalization
+normalization = [
+    "dateparser>=1.2.0"
+]
+
 # Keyword extraction
 keywords = [
     "yake>=0.4.8"

--- a/src/mnemotree/core/builder.py
+++ b/src/mnemotree/core/builder.py
@@ -16,6 +16,7 @@ from .memory import (
     MemoryMode,
     ModeDefaultsConfig,
     NerConfig,
+    NormalizationConfig,
     RetrievalConfig,
     RetrievalMode,
     ScoringConfig,
@@ -36,6 +37,7 @@ class MemoryCoreBuilder:
         self._scoring_config = ScoringConfig()
         self._retrieval_config = RetrievalConfig()
         self._ingestion_config = IngestionConfig()
+        self._normalization_config = NormalizationConfig()
 
     @classmethod
     def lite(cls, store: MemoryCRUDStore) -> MemoryCoreBuilder:
@@ -201,6 +203,21 @@ class MemoryCoreBuilder:
         self._retrieval_config = replace(self._retrieval_config, enable_prf=False)
         return self
 
+    def with_normalization(
+        self,
+        *,
+        enable_coref: bool = True,
+        enable_temporal: bool = True,
+        coref_backend: str = "heuristic",
+    ) -> MemoryCoreBuilder:
+        """Enable content normalization (coreference resolution + temporal anchoring)."""
+        self._normalization_config = NormalizationConfig(
+            enable_coref=enable_coref,
+            enable_temporal=enable_temporal,
+            coref_backend=coref_backend,
+        )
+        return self
+
     def with_defaults(
         self,
         *,
@@ -221,6 +238,10 @@ class MemoryCoreBuilder:
             "scoring_config": (ScoringConfig, lambda v: setattr(self, "_scoring_config", v)),
             "retrieval_config": (RetrievalConfig, lambda v: setattr(self, "_retrieval_config", v)),
             "ingestion_config": (IngestionConfig, lambda v: setattr(self, "_ingestion_config", v)),
+            "normalization_config": (
+                NormalizationConfig,
+                lambda v: setattr(self, "_normalization_config", v),
+            ),
         }
         option = typed_options.get(name)
         if option and isinstance(value, option[0]):
@@ -310,4 +331,5 @@ class MemoryCoreBuilder:
             scoring_config=self._scoring_config,
             retrieval_config=self._retrieval_config,
             ingestion_config=self._ingestion_config,
+            normalization_config=self._normalization_config,
         )

--- a/src/mnemotree/core/memory.py
+++ b/src/mnemotree/core/memory.py
@@ -90,6 +90,13 @@ class RetrievalConfig:
 
 
 @dataclass(frozen=True)
+class NormalizationConfig:
+    enable_coref: bool = False
+    enable_temporal: bool = False
+    coref_backend: str = "heuristic"
+
+
+@dataclass(frozen=True)
 class IngestionConfig:
     async_ingest: bool = False
     ingestion_queue_size: int = 100
@@ -164,6 +171,7 @@ class MemoryCore:
         scoring_config: ScoringConfig | None = None,
         retrieval_config: RetrievalConfig | None = None,
         ingestion_config: IngestionConfig | None = None,
+        normalization_config: NormalizationConfig | None = None,
     ):
         """
         Initializes the MemoryCore.
@@ -177,6 +185,7 @@ class MemoryCore:
             scoring_config: Scoring defaults and pre-remember hooks.
             retrieval_config: Retrieval and reranking configuration.
             ingestion_config: Async ingestion configuration.
+            normalization_config: Content normalization configuration.
         """
         self.store = store
 
@@ -185,6 +194,7 @@ class MemoryCore:
         scoring_config = scoring_config or ScoringConfig()
         retrieval_config = retrieval_config or RetrievalConfig()
         ingestion_config = ingestion_config or IngestionConfig()
+        normalization_config = normalization_config or NormalizationConfig()
 
         self._init_runtime_settings(
             mode=mode_defaults.mode,
@@ -236,6 +246,7 @@ class MemoryCore:
             enable_rrf_signal_rerank=retrieval_config.enable_rrf_signal_rerank,
             rerank_candidates=retrieval_config.rerank_candidates,
         )
+        self._init_normalizer(normalization_config)
 
     async def remember(
         self,
@@ -448,6 +459,9 @@ class MemoryCore:
         user_id: str | None = None,
     ) -> MemoryItem:
         analyze, summarize = self._resolve_analysis_flags(analyze, summarize)
+
+        if self.normalizer:
+            content = await self.normalizer.normalize(content, context)
 
         enrichment = await self.enrichment.enrich(
             content, context, analyze=analyze, summarize=summarize
@@ -1593,6 +1607,15 @@ class MemoryCore:
             rrf_k=rrf_k,
             enable_rrf_signal_rerank=enable_rrf_signal_rerank,
             rerank_candidates=rerank_candidates,
+        )
+
+    def _init_normalizer(self, config: NormalizationConfig) -> None:
+        from ..normalization import create_normalization_pipeline
+
+        self.normalizer = create_normalization_pipeline(
+            enable_coref=config.enable_coref,
+            enable_temporal=config.enable_temporal,
+            coref_backend=config.coref_backend,
         )
 
     def _build_retriever(

--- a/src/mnemotree/normalization/__init__.py
+++ b/src/mnemotree/normalization/__init__.py
@@ -1,0 +1,51 @@
+"""Content normalization for memory ingestion.
+
+Provides coreference resolution and temporal anchoring to improve
+retrieval quality by replacing pronouns with proper names and
+relative dates with absolute dates.
+"""
+
+from __future__ import annotations
+
+from .base import BaseNormalizer
+from .coref import CoreferenceNormalizer
+from .pipeline import NormalizationPipeline
+from .temporal import TemporalNormalizer
+
+
+def create_normalization_pipeline(
+    *,
+    enable_coref: bool = False,
+    enable_temporal: bool = False,
+    coref_backend: str = "heuristic",
+) -> NormalizationPipeline | None:
+    """Create a normalization pipeline based on configuration.
+
+    Args:
+        enable_coref: Enable coreference resolution.
+        enable_temporal: Enable temporal anchoring.
+        coref_backend: Coreference backend ("heuristic" or "fastcoref").
+
+    Returns:
+        A configured NormalizationPipeline, or None if nothing is enabled.
+    """
+    normalizers: list[BaseNormalizer] = []
+
+    if enable_coref:
+        normalizers.append(CoreferenceNormalizer(backend=coref_backend))
+    if enable_temporal:
+        normalizers.append(TemporalNormalizer())
+
+    if not normalizers:
+        return None
+
+    return NormalizationPipeline(normalizers)
+
+
+__all__ = [
+    "BaseNormalizer",
+    "CoreferenceNormalizer",
+    "NormalizationPipeline",
+    "TemporalNormalizer",
+    "create_normalization_pipeline",
+]

--- a/src/mnemotree/normalization/base.py
+++ b/src/mnemotree/normalization/base.py
@@ -1,0 +1,28 @@
+"""Abstract base class for content normalizers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseNormalizer(ABC):
+    """Base class for content normalizers.
+
+    Normalizers transform raw memory content before storage to improve
+    retrieval quality (e.g., resolving pronouns, anchoring relative dates).
+    """
+
+    @abstractmethod
+    async def normalize(self, content: str, context: dict[str, Any] | None = None) -> str:
+        """Normalize content text.
+
+        Args:
+            content: Raw content string to normalize.
+            context: Optional context dict with metadata such as speaker names,
+                     reference dates, recent entities, etc.
+
+        Returns:
+            Normalized content string.
+        """
+        ...

--- a/src/mnemotree/normalization/coref.py
+++ b/src/mnemotree/normalization/coref.py
@@ -1,0 +1,125 @@
+"""Coreference resolution normalizer.
+
+Resolves pronouns in memory content to their referents so that stored text
+contains proper names instead of ambiguous pronouns like "he", "she", "they".
+
+Two backends:
+  - "heuristic" (default): regex-based, no extra dependencies
+  - "fastcoref": neural coreference using biu-nlp/f-coref model
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .base import BaseNormalizer
+
+# Patterns for first-person pronoun replacement (speaker → speaker name).
+# Each tuple: (pattern, replacement template) where {name} is substituted.
+_FIRST_PERSON = [
+    # Standalone words only (word boundaries)
+    (re.compile(r"\bI\b(?!')"), "{name}"),
+    (re.compile(r"\bme\b", re.IGNORECASE), "{name}"),
+    (re.compile(r"\bmy\b", re.IGNORECASE), "{name}'s"),
+    (re.compile(r"\bmine\b", re.IGNORECASE), "{name}'s"),
+    (re.compile(r"\bmyself\b", re.IGNORECASE), "{name}"),
+]
+
+# Third-person singular pronouns (mapped to the other speaker).
+_THIRD_PERSON_PATTERNS = [
+    (re.compile(r"\b[Hh]e\b"), "{name}"),
+    (re.compile(r"\b[Ss]he\b"), "{name}"),
+    (re.compile(r"\b[Hh]im\b"), "{name}"),
+    (re.compile(r"\b[Hh]er\b(?!\s+\w+ing)"), "{name}"),  # avoid "her doing"
+    (re.compile(r"\b[Hh]is\b"), "{name}'s"),
+    (re.compile(r"\b[Hh]ers\b"), "{name}'s"),
+    (re.compile(r"\b[Hh]imself\b"), "{name}"),
+    (re.compile(r"\b[Hh]erself\b"), "{name}"),
+]
+
+# Pattern to extract speaker and text from LoCoMo-style formatted content:
+# "[date] Speaker: text"
+_SPEAKER_PATTERN = re.compile(r"^\[.*?\]\s*(\w[\w\s]*?):\s*(.*)$", re.DOTALL)
+
+
+class CoreferenceNormalizer(BaseNormalizer):
+    """Resolve coreferences (pronouns) in memory content.
+
+    Args:
+        backend: "heuristic" for regex-based resolution (default, no deps),
+                 "fastcoref" for neural resolution (requires fastcoref package).
+    """
+
+    def __init__(self, backend: str = "heuristic") -> None:
+        self.backend = backend
+        self._fastcoref_model: Any = None
+
+    async def normalize(self, content: str, context: dict[str, Any] | None = None) -> str:
+        if self.backend == "fastcoref":
+            return self._normalize_fastcoref(content, context)
+        return self._normalize_heuristic(content, context)
+
+    # ------------------------------------------------------------------
+    # Heuristic backend
+    # ------------------------------------------------------------------
+
+    def _normalize_heuristic(self, content: str, context: dict[str, Any] | None = None) -> str:
+        ctx = context or {}
+        speaker = ctx.get("speaker")
+        other_speaker = ctx.get("other_speaker")
+
+        # Try to parse speaker from content format "[date] Speaker: text"
+        match = _SPEAKER_PATTERN.match(content)
+        if match and not speaker:
+            speaker = match.group(1).strip()
+
+        if not speaker:
+            return content
+
+        # Extract the text portion after "Speaker:"
+        if match:
+            prefix = content[: match.start(2)]
+            text = match.group(2)
+        else:
+            prefix = ""
+            text = content
+
+        # Replace first-person pronouns with speaker name
+        for pattern, template in _FIRST_PERSON:
+            text = pattern.sub(template.format(name=speaker), text)
+
+        # Replace third-person pronouns with other_speaker if unambiguous
+        if other_speaker:
+            # Only replace if there's a single candidate referent
+            recent_entities = ctx.get("recent_entities", [])
+            # If we have recent entities, check for ambiguity
+            person_candidates = {other_speaker}
+            for entity in recent_entities:
+                if isinstance(entity, str) and entity != speaker:
+                    person_candidates.add(entity)
+
+            # Only resolve if unambiguous (single candidate)
+            if len(person_candidates) == 1:
+                for pattern, template in _THIRD_PERSON_PATTERNS:
+                    text = pattern.sub(template.format(name=other_speaker), text)
+
+        return prefix + text
+
+    # ------------------------------------------------------------------
+    # fastcoref backend
+    # ------------------------------------------------------------------
+
+    def _normalize_fastcoref(self, content: str, context: dict[str, Any] | None = None) -> str:
+        try:
+            from fastcoref import FCoref
+        except ImportError:
+            # Fall back to heuristic if fastcoref not installed
+            return self._normalize_heuristic(content, context)
+
+        if self._fastcoref_model is None:
+            self._fastcoref_model = FCoref()
+
+        preds = self._fastcoref_model.predict(texts=[content])
+        resolved = preds[0].get_resolved_text()
+        return resolved if resolved else content

--- a/src/mnemotree/normalization/pipeline.py
+++ b/src/mnemotree/normalization/pipeline.py
@@ -1,0 +1,38 @@
+"""Normalization pipeline that chains multiple normalizers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import BaseNormalizer
+
+
+class NormalizationPipeline:
+    """Sequential chain of normalizers applied to content before storage.
+
+    Each normalizer transforms the content in order, passing the result
+    to the next normalizer in the chain.
+    """
+
+    def __init__(self, normalizers: list[BaseNormalizer]) -> None:
+        self.normalizers = normalizers
+
+    async def normalize(self, content: str, context: dict[str, Any] | None = None) -> str:
+        """Run all normalizers sequentially on the content.
+
+        Args:
+            content: Raw content string.
+            context: Optional context dict passed to each normalizer.
+
+        Returns:
+            Normalized content after all normalizers have been applied.
+        """
+        for normalizer in self.normalizers:
+            content = await normalizer.normalize(content, context)
+        return content
+
+    def __len__(self) -> int:
+        return len(self.normalizers)
+
+    def __bool__(self) -> bool:
+        return len(self.normalizers) > 0

--- a/src/mnemotree/normalization/temporal.py
+++ b/src/mnemotree/normalization/temporal.py
@@ -1,0 +1,128 @@
+"""Temporal anchoring normalizer.
+
+Replaces relative temporal expressions (e.g., "yesterday", "next Monday",
+"3 days ago") with absolute ISO-8601 dates, using the reference date
+extracted from the content or provided in context.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from .base import BaseNormalizer
+
+# Pattern to extract LoCoMo-style date prefix: [1:56 pm on 8 May, 2023]
+_LOCOMO_DATE_PREFIX = re.compile(r"^\[([^\]]+)\]")
+
+# Relative temporal expressions to detect and replace.
+_RELATIVE_PATTERNS = [
+    # "yesterday", "today", "tomorrow"
+    re.compile(r"\byesterday\b", re.IGNORECASE),
+    re.compile(r"\btomorrow\b", re.IGNORECASE),
+    re.compile(r"\btoday\b", re.IGNORECASE),
+    # "next Monday", "last Friday", etc.
+    re.compile(
+        r"\b(next|last|this)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        re.IGNORECASE,
+    ),
+    # "next week", "last month", "next year"
+    re.compile(r"\b(next|last|this)\s+(week|month|year)\b", re.IGNORECASE),
+    # "N days/weeks/months ago"
+    re.compile(r"\b(\d+)\s+(days?|weeks?|months?|years?)\s+ago\b", re.IGNORECASE),
+    # "in N days/weeks/months"
+    re.compile(r"\bin\s+(\d+)\s+(days?|weeks?|months?|years?)\b", re.IGNORECASE),
+    # "the day after tomorrow", "the day before yesterday"
+    re.compile(r"\bthe\s+day\s+after\s+tomorrow\b", re.IGNORECASE),
+    re.compile(r"\bthe\s+day\s+before\s+yesterday\b", re.IGNORECASE),
+]
+
+
+def _parse_reference_date(content: str, context: dict[str, Any] | None = None) -> datetime | None:
+    """Extract reference date from content prefix or context."""
+    # Try context first
+    if context:
+        ref = context.get("reference_date")
+        if isinstance(ref, datetime):
+            return ref
+        if isinstance(ref, str):
+            return _parse_date_string(ref)
+
+    # Try to parse from LoCoMo-style prefix
+    match = _LOCOMO_DATE_PREFIX.match(content)
+    if match:
+        return _parse_date_string(match.group(1))
+
+    return None
+
+
+def _parse_date_string(date_str: str) -> datetime | None:
+    """Parse a date string using dateparser if available, else common formats."""
+    try:
+        import dateparser
+
+        parsed = dateparser.parse(date_str)
+        if parsed:
+            return parsed
+    except ImportError:
+        pass
+
+    # Fallback: try common formats
+    for fmt in (
+        "%I:%M %p on %d %B, %Y",
+        "%I:%M %p on %B %d, %Y",
+        "%d %B, %Y",
+        "%B %d, %Y",
+        "%Y-%m-%d",
+        "%d/%m/%Y",
+        "%m/%d/%Y",
+    ):
+        try:
+            return datetime.strptime(date_str.strip(), fmt)
+        except ValueError:
+            continue
+    return None
+
+
+class TemporalNormalizer(BaseNormalizer):
+    """Anchor relative temporal expressions to absolute dates."""
+
+    async def normalize(self, content: str, context: dict[str, Any] | None = None) -> str:
+        ref_date = _parse_reference_date(content, context)
+        if ref_date is None:
+            return content
+
+        # Find all relative temporal expressions and replace them
+        result = content
+        for pattern in _RELATIVE_PATTERNS:
+            result = self._replace_temporal(result, pattern, ref_date)
+
+        return result
+
+    def _replace_temporal(self, text: str, pattern: re.Pattern, ref_date: datetime) -> str:
+        """Replace matches of a temporal pattern with resolved dates."""
+
+        def _replacer(match: re.Match) -> str:
+            expr = match.group(0)
+            resolved = self._resolve_expression(expr, ref_date)
+            if resolved:
+                return f"{expr} ({resolved})"
+            return expr
+
+        return pattern.sub(_replacer, text)
+
+    @staticmethod
+    def _resolve_expression(expr: str, ref_date: datetime) -> str | None:
+        """Resolve a relative temporal expression to an ISO date string."""
+        try:
+            import dateparser
+
+            settings = {"RELATIVE_BASE": ref_date}
+            parsed = dateparser.parse(expr, settings=settings)
+            if parsed and parsed != ref_date:
+                return parsed.strftime("%Y-%m-%d")
+        except ImportError:
+            pass
+
+        return None

--- a/src/mnemotree/store/neo4j_store.py
+++ b/src/mnemotree/store/neo4j_store.py
@@ -1282,7 +1282,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                 async for record in result:
                     node_data = dict(record["source"])
                     try:
-                        memory = parse_neo4j_node_data(node_data)
+                        memory = MemoryItem(**parse_neo4j_node_data(node_data))
                         memories.append(memory)
                     except (ValidationError, ValueError) as e:
                         logger.warning(
@@ -1363,7 +1363,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                     rels = record["rels"]
 
                     try:
-                        memory = parse_neo4j_node_data(node_data)
+                        memory = MemoryItem(**parse_neo4j_node_data(node_data))
                         path_links = []
                         for r in rels:
                             metadata_str = r.get("metadata", "{}")
@@ -1459,7 +1459,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                 # Skip first node (source), include others
                 for _i, (node, rel) in enumerate(zip(nodes[1:], rels, strict=False)):
                     node_data = dict(node)
-                    memory = parse_neo4j_node_data(node_data)
+                    memory = MemoryItem(**parse_neo4j_node_data(node_data))
 
                     metadata_str = rel.get("metadata", "{}")
                     link = MemoryLink(

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -547,8 +547,8 @@ def test_build_with_normalization(mock_store, mock_embeddings):
     )
     assert isinstance(core, MemoryCore)
     assert core.normalizer is not None
-    
-    
+
+
 # --- Cross-Encoder Reranker Tests ---
 
 

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -10,6 +10,7 @@ from mnemotree.core.memory import (
     MemoryCore,
     ModeDefaultsConfig,
     NerConfig,
+    NormalizationConfig,
     RetrievalConfig,
     ScoringConfig,
 )
@@ -502,3 +503,47 @@ def test_build_passes_all_configs(mock_store, mock_llm, mock_embeddings):
     assert abs(core.default_importance - 0.7) < 1e-9
     assert core.enable_bm25 is True
     assert core.retrieval_mode == "hybrid"
+
+
+# --- Normalization Tests ---
+
+
+def test_with_normalization_defaults(mock_store):
+    """Test with_normalization() sets defaults correctly."""
+    builder = MemoryCoreBuilder(mock_store).with_normalization()
+    assert builder._normalization_config.enable_coref is True
+    assert builder._normalization_config.enable_temporal is True
+    assert builder._normalization_config.coref_backend == "heuristic"
+
+
+def test_with_normalization_custom(mock_store):
+    """Test with_normalization() with custom parameters."""
+    builder = MemoryCoreBuilder(mock_store).with_normalization(
+        enable_coref=True,
+        enable_temporal=False,
+        coref_backend="fastcoref",
+    )
+    assert builder._normalization_config.enable_coref is True
+    assert builder._normalization_config.enable_temporal is False
+    assert builder._normalization_config.coref_backend == "fastcoref"
+
+
+def test_with_option_normalization_config(mock_store):
+    """Test with_option() for normalization_config."""
+    config = NormalizationConfig(enable_coref=True, enable_temporal=True)
+    builder = MemoryCoreBuilder(mock_store).with_option("normalization_config", config)
+    assert builder._normalization_config is config
+
+
+def test_build_with_normalization(mock_store, mock_embeddings):
+    """Test that build() creates MemoryCore with normalization."""
+    core = (
+        MemoryCoreBuilder(mock_store)
+        .with_embeddings(mock_embeddings)
+        .disable_keywords()
+        .disable_ner()
+        .with_normalization(enable_coref=True, enable_temporal=True)
+        .build()
+    )
+    assert isinstance(core, MemoryCore)
+    assert core.normalizer is not None

--- a/tests/normalization/test_coref.py
+++ b/tests/normalization/test_coref.py
@@ -1,0 +1,98 @@
+"""Tests for CoreferenceNormalizer."""
+
+import pytest
+
+from mnemotree.normalization.coref import CoreferenceNormalizer
+
+
+@pytest.fixture
+def normalizer():
+    return CoreferenceNormalizer(backend="heuristic")
+
+
+async def test_first_person_replacement_with_context(normalizer):
+    """First-person pronouns should be replaced with speaker name."""
+    content = "[1:00 pm on 8 May, 2023] Alice: I love my new car and it makes me happy"
+    context = {"speaker": "Alice", "other_speaker": "Bob"}
+
+    result = await normalizer.normalize(content, context)
+
+    assert "Alice love Alice's new car" in result
+    assert "makes Alice happy" in result
+
+
+async def test_first_person_parsed_from_content(normalizer):
+    """Speaker should be parsed from LoCoMo format when not in context."""
+    content = "[1:00 pm on 8 May, 2023] Alice: I went to the store"
+
+    result = await normalizer.normalize(content)
+
+    assert "Alice went to the store" in result
+
+
+async def test_third_person_replacement_unambiguous(normalizer):
+    """Third-person pronouns replaced when single other_speaker and no ambiguity."""
+    content = "[1:00 pm on 8 May, 2023] Alice: He went to the park"
+    context = {
+        "speaker": "Alice",
+        "other_speaker": "Bob",
+        "recent_entities": [],
+    }
+
+    result = await normalizer.normalize(content, context)
+
+    assert "Bob went to the park" in result
+
+
+async def test_third_person_skipped_when_ambiguous(normalizer):
+    """Third-person pronouns NOT replaced when multiple candidates exist."""
+    content = "[1:00 pm on 8 May, 2023] Alice: He went to the park"
+    context = {
+        "speaker": "Alice",
+        "other_speaker": "Bob",
+        "recent_entities": ["Charlie"],  # extra person creates ambiguity
+    }
+
+    result = await normalizer.normalize(content, context)
+
+    # Should NOT replace "He" because there are multiple candidates
+    assert "He went to the park" in result
+
+
+async def test_no_context_no_change(normalizer):
+    """Without context, content should be unchanged (except parsed speaker)."""
+    content = "Just a plain string without speaker format"
+
+    result = await normalizer.normalize(content)
+
+    assert result == content
+
+
+async def test_possessive_his_replacement(normalizer):
+    """Possessive 'his' should become 'Name's'."""
+    content = "[1:00 pm on 8 May, 2023] Alice: His dog is cute"
+    context = {
+        "speaker": "Alice",
+        "other_speaker": "Bob",
+        "recent_entities": [],
+    }
+
+    result = await normalizer.normalize(content, context)
+
+    assert "Bob's dog is cute" in result
+
+
+async def test_speaker_with_spaces(normalizer):
+    """Speaker names with spaces should work."""
+    content = "[1:00 pm on 8 May, 2023] John Smith: I like my job"
+    context = {"speaker": "John Smith"}
+
+    result = await normalizer.normalize(content, context)
+
+    assert "John Smith like John Smith's job" in result
+
+
+async def test_empty_content(normalizer):
+    """Empty content should return empty."""
+    result = await normalizer.normalize("")
+    assert result == ""

--- a/tests/normalization/test_pipeline.py
+++ b/tests/normalization/test_pipeline.py
@@ -1,0 +1,103 @@
+"""Tests for NormalizationPipeline and factory."""
+
+from mnemotree.normalization import create_normalization_pipeline
+from mnemotree.normalization.base import BaseNormalizer
+from mnemotree.normalization.pipeline import NormalizationPipeline
+
+
+class UpperNormalizer(BaseNormalizer):
+    """Test normalizer that uppercases content."""
+
+    async def normalize(self, content, context=None):
+        return content.upper()
+
+
+class SuffixNormalizer(BaseNormalizer):
+    """Test normalizer that appends a suffix."""
+
+    async def normalize(self, content, context=None):
+        return content + " [normalized]"
+
+
+async def test_pipeline_chains_normalizers():
+    """Pipeline should apply normalizers in sequence."""
+    pipeline = NormalizationPipeline([UpperNormalizer(), SuffixNormalizer()])
+    result = await pipeline.normalize("hello world")
+    assert result == "HELLO WORLD [normalized]"
+
+
+async def test_pipeline_order_matters():
+    """Order of normalizers should affect output."""
+    pipeline = NormalizationPipeline([SuffixNormalizer(), UpperNormalizer()])
+    result = await pipeline.normalize("hello world")
+    assert result == "HELLO WORLD [NORMALIZED]"
+
+
+async def test_empty_pipeline():
+    """Empty pipeline should return content unchanged."""
+    pipeline = NormalizationPipeline([])
+    result = await pipeline.normalize("hello world")
+    assert result == "hello world"
+
+
+async def test_pipeline_passes_context():
+    """Context should be passed to each normalizer."""
+
+    class ContextCapture(BaseNormalizer):
+        captured_context = None
+
+        async def normalize(self, content, context=None):
+            ContextCapture.captured_context = context
+            return content
+
+    pipeline = NormalizationPipeline([ContextCapture()])
+    ctx = {"speaker": "Alice"}
+    await pipeline.normalize("test", ctx)
+    assert ContextCapture.captured_context == ctx
+
+
+def test_pipeline_bool_empty():
+    """Empty pipeline should be falsy."""
+    assert not NormalizationPipeline([])
+
+
+def test_pipeline_bool_nonempty():
+    """Non-empty pipeline should be truthy."""
+    assert NormalizationPipeline([UpperNormalizer()])
+
+
+def test_pipeline_len():
+    """len() should return number of normalizers."""
+    assert len(NormalizationPipeline([])) == 0
+    assert len(NormalizationPipeline([UpperNormalizer()])) == 1
+    assert len(NormalizationPipeline([UpperNormalizer(), SuffixNormalizer()])) == 2
+
+
+# --- Factory tests ---
+
+
+def test_factory_nothing_enabled():
+    """Factory returns None when nothing is enabled."""
+    result = create_normalization_pipeline()
+    assert result is None
+
+
+def test_factory_coref_only():
+    """Factory creates pipeline with coref only."""
+    result = create_normalization_pipeline(enable_coref=True)
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_factory_temporal_only():
+    """Factory creates pipeline with temporal only."""
+    result = create_normalization_pipeline(enable_temporal=True)
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_factory_both_enabled():
+    """Factory creates pipeline with both normalizers."""
+    result = create_normalization_pipeline(enable_coref=True, enable_temporal=True)
+    assert result is not None
+    assert len(result) == 2

--- a/tests/normalization/test_temporal.py
+++ b/tests/normalization/test_temporal.py
@@ -1,0 +1,104 @@
+"""Tests for TemporalNormalizer."""
+
+from datetime import datetime
+
+import pytest
+
+from mnemotree.normalization.temporal import TemporalNormalizer, _parse_reference_date
+
+
+@pytest.fixture
+def normalizer():
+    return TemporalNormalizer()
+
+
+def test_parse_reference_date_from_context():
+    """Reference date should be extracted from context."""
+    ctx = {"reference_date": datetime(2023, 5, 8, 13, 0)}
+    result = _parse_reference_date("some content", ctx)
+    assert result == datetime(2023, 5, 8, 13, 0)
+
+
+def test_parse_reference_date_from_content():
+    """Reference date should be parsed from LoCoMo-style prefix."""
+    content = "[1:56 pm on 8 May, 2023] Alice: hello"
+    result = _parse_reference_date(content)
+    assert result is not None
+    assert result.year == 2023
+    assert result.month == 5
+    assert result.day == 8
+
+
+def test_parse_reference_date_no_date():
+    """No reference date returns None."""
+    result = _parse_reference_date("plain text", None)
+    assert result is None
+
+
+async def test_no_reference_date_no_change(normalizer):
+    """Without reference date, content should be unchanged."""
+    content = "I'll do it tomorrow"
+    result = await normalizer.normalize(content)
+    assert result == content
+
+
+async def test_relative_expression_annotated(normalizer):
+    """Relative expressions should get ISO date annotations when dateparser available."""
+    content = "[1:56 pm on 8 May, 2023] Alice: I'll see you tomorrow"
+    context = {"reference_date": datetime(2023, 5, 8, 13, 56)}
+
+    result = await normalizer.normalize(content, context)
+
+    # If dateparser is installed, "tomorrow" should be annotated
+    try:
+        import dateparser  # noqa: F401
+
+        assert "2023-05-09" in result
+    except ImportError:
+        # Without dateparser, content unchanged
+        assert result == content
+
+
+async def test_yesterday_annotated(normalizer):
+    """'yesterday' should be annotated with correct date."""
+    context = {"reference_date": datetime(2023, 5, 8)}
+    content = "[1:00 pm on 8 May, 2023] Bob: I did it yesterday"
+
+    result = await normalizer.normalize(content, context)
+
+    try:
+        import dateparser  # noqa: F401
+
+        assert "2023-05-07" in result
+    except ImportError:
+        assert result == content
+
+
+async def test_n_days_ago_annotated(normalizer):
+    """'3 days ago' should be annotated."""
+    context = {"reference_date": datetime(2023, 5, 8)}
+    content = "[1:00 pm on 8 May, 2023] Alice: We met 3 days ago"
+
+    result = await normalizer.normalize(content, context)
+
+    try:
+        import dateparser  # noqa: F401
+
+        assert "2023-05-05" in result
+    except ImportError:
+        assert result == content
+
+
+async def test_no_temporal_expressions_unchanged(normalizer):
+    """Content without temporal expressions should be unchanged."""
+    content = "[1:00 pm on 8 May, 2023] Alice: I love pizza"
+    context = {"reference_date": datetime(2023, 5, 8)}
+
+    result = await normalizer.normalize(content, context)
+    assert result == content
+
+
+async def test_empty_content(normalizer):
+    """Empty content should return empty."""
+    result = await normalizer.normalize("")
+    assert result == ""


### PR DESCRIPTION
## Summary
- Add `NormalizationConfig` dataclass and `normalization_config` parameter to `MemoryCore.__init__`
- Implement `_init_normalizer()` that lazily creates a normalization pipeline (coreference resolution + temporal anchoring)
- Integrate normalization into `_remember_sync()` so content is normalized before enrichment
- Add `with_normalization()` builder method and `with_option("normalization_config", ...)` support
- Add `normalization` optional dependency group (`dateparser>=1.2.0`) to pyproject.toml

## Test plan
- [ ] `test_with_normalization_defaults` — verify default config values
- [ ] `test_with_normalization_custom` — verify custom coref_backend passthrough
- [ ] `test_with_option_normalization_config` — verify config object passthrough
- [ ] `test_build_with_normalization` — verify MemoryCore builds with normalizer active
- [ ] Run full test suite: `pytest tests/core/test_builder.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)