### PR TITLE
feat: Knowledge graph support with SQLite default store

### DIFF
--- a/examples/knowledge_graph_demo.py
+++ b/examples/knowledge_graph_demo.py
@@ -14,55 +14,61 @@ Works in BOTH lite and pro modes - no LLM required!
 """
 
 import asyncio
+import tempfile
+from pathlib import Path
 
-from mnemotree import LinkType, MemoryCore, MemoryType
+from mnemotree import LinkType, MemoryCoreBuilder, MemoryType
+from mnemotree.store.sqlite_vec_store import SQLiteVecMemoryStore
 
 
 async def main():
-    # Initialize in lite mode (no API key needed)
-    core = MemoryCore.from_config("neo4j", mode="lite")
+    # Initialize with SQLite — no external dependencies needed
+    db_path = Path(tempfile.mkdtemp()) / "demo.sqlite"
+    store = SQLiteVecMemoryStore(db_path=db_path)
+    await store.initialize()
+    core = MemoryCoreBuilder.lite(store).build()
 
-    print("🧠 Mnemotree Knowledge Graph Demo")
+    print("Mnemotree Knowledge Graph Demo")
     print("=" * 50)
     print()
 
     # Create a small knowledge base about memory systems
-    print("📝 Creating memories...")
+    print("Creating memories...")
 
     m1 = await core.remember(
         "FSRS (Free Spaced Repetition Scheduler) is an algorithm for optimizing memory retention",
         memory_type=MemoryType.SEMANTIC,
     )
-    print(f"  ✓ Created: {m1.content[:50]}...")
+    print(f"  Created: {m1.content[:50]}...")
 
     m2 = await core.remember(
         "Spaced repetition works by reviewing information at increasing intervals",
         memory_type=MemoryType.SEMANTIC,
     )
-    print(f"  ✓ Created: {m2.content[:50]}...")
+    print(f"  Created: {m2.content[:50]}...")
 
     m3 = await core.remember(
         "The forgetting curve shows that we forget ~50% of new information within 1 hour",
         memory_type=MemoryType.SEMANTIC,
     )
-    print(f"  ✓ Created: {m3.content[:50]}...")
+    print(f"  Created: {m3.content[:50]}...")
 
     m4 = await core.remember(
         "Zettelkasten is a note-taking method that uses interconnected notes",
         memory_type=MemoryType.SEMANTIC,
     )
-    print(f"  ✓ Created: {m4.content[:50]}...")
+    print(f"  Created: {m4.content[:50]}...")
 
     m5 = await core.remember(
         "Roam Research popularized bidirectional links in note-taking apps",
         memory_type=MemoryType.SEMANTIC,
     )
-    print(f"  ✓ Created: {m5.content[:50]}...")
+    print(f"  Created: {m5.content[:50]}...")
 
     print()
 
     # Create typed links
-    print("🔗 Creating knowledge graph links...")
+    print("Creating knowledge graph links...")
 
     # m2 elaborates on why FSRS works
     link1 = await core.link(
@@ -71,7 +77,7 @@ async def main():
         LinkType.ELABORATES,
         context="Explains the mechanism behind FSRS",
     )
-    print(f"  ✓ {LinkType.ELABORATES.value}: m2 → m1")
+    print(f"  {LinkType.ELABORATES.value}: m2 -> m1")
 
     # m3 supports the need for spaced repetition
     link2 = await core.link(
@@ -80,7 +86,7 @@ async def main():
         LinkType.SUPPORTS,
         context="Provides evidence for why spaced repetition is needed",
     )
-    print(f"  ✓ {LinkType.SUPPORTS.value}: m3 → m2")
+    print(f"  {LinkType.SUPPORTS.value}: m3 -> m2")
 
     # m4 and m5 are similar concepts
     link3 = await core.link(
@@ -90,28 +96,35 @@ async def main():
         context="Both are modern note-taking systems with linked notes",
         bidirectional=True,  # Create reverse link too
     )
-    print(f"  ✓ {LinkType.SIMILAR_TO.value}: m4 ↔ m5 (bidirectional)")
+    print(f"  {LinkType.SIMILAR_TO.value}: m4 <-> m5 (bidirectional)")
 
-    # Zettelkasten derives from earlier slip-box methods
     print()
 
     # Find backlinks (what references this concept?)
-    print("🔍 Finding backlinks...")
+    print("Finding backlinks...")
     print()
     backlinks = await core.get_backlinks(m1.memory_id)
     print(f"Memories that link TO '{m1.content[:40]}...':")
     for mem in backlinks:
-        print(f"  ← {mem.content[:60]}...")
+        print(f"  <- {mem.content[:60]}...")
     print()
 
     backlinks_m2 = await core.get_backlinks(m2.memory_id)
     print(f"Memories that link TO '{m2.content[:40]}...':")
     for mem in backlinks_m2:
-        print(f"  ← {mem.content[:60]}...")
+        print(f"  <- {mem.content[:60]}...")
+    print()
+
+    # Get links for a memory
+    print("Getting links...")
+    links = await core.get_links(m2.memory_id)
+    print(f"All links for '{m2.content[:40]}...':")
+    for link in links:
+        print(f"  {link.link_type.value}: {link.source_id[:8]}... -> {link.target_id[:8]}...")
     print()
 
     # Explore graph neighborhood
-    print("🌐 Exploring graph neighborhood...")
+    print("Exploring graph neighborhood...")
     graph = await core.explore(m1.memory_id, depth=2)
     print(f"Graph around '{m1.content[:40]}...':")
     print(f"  Nodes: {graph['node_count']}")
@@ -122,10 +135,10 @@ async def main():
     print()
 
     # Find connection path
-    print("🔎 Finding connections...")
+    print("Finding connections...")
     path = await core.find_connection(m3.memory_id, m1.memory_id)
     if path:
-        print(f"Path from m3 → m1:")
+        print(f"Path from m3 -> m1:")
         for i, step in enumerate(path, 1):
             print(f"  {i}. {step['memory']['content'][:50]}...")
             print(f"     via {step['link']['type']} link")
@@ -136,15 +149,15 @@ async def main():
 
     print()
     print("=" * 50)
-    print("✅ Demo complete!")
+    print("Demo complete!")
     print()
     print("Key takeaways:")
-    print("  • Typed links (ELABORATES, SUPPORTS, SIMILAR_TO, etc.)")
-    print("  • Bidirectional discovery (backlinks)")
-    print("  • Graph traversal and exploration")
-    print("  • No LLM required - works in lite mode!")
+    print("  - Typed links (ELABORATES, SUPPORTS, SIMILAR_TO, etc.)")
+    print("  - Bidirectional discovery (backlinks)")
+    print("  - Graph traversal and exploration")
+    print("  - No LLM required - works in lite mode!")
 
-    await core.close()
+    await store.close()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "urllib3>=2.6.0,<3.0.0",
     "filelock>=3.20.3,<4.0.0",
 
+    # Default store — SQLite with vector search (zero-infra)
+    "sqlite-vec>=0.1.0",
+
     # Langchain
     "langchain>=0.3.7,<0.4.0",
     "langchain-openai>=0.2.14,<0.3.0",
@@ -90,7 +93,6 @@ ui = ["streamlit>=1.40.0"]
 # MCP server
 mcp = ["fastmcp<3"]
 mcp_server = [
-    "chromadb>=0.5.23",
     "fastmcp<3",
     "sentence-transformers>=2.7.0",
 ]

--- a/src/mnemotree/__init__.py
+++ b/src/mnemotree/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .core.builder import MemoryCoreBuilder
 from .core.memory import MemoryCore, MemoryMode, RecallFilters, RecallOptions, RememberOptions
+from .core.models import LinkType, MemoryLink
 from .errors import (
     ConfigurationError,
     DependencyError,
@@ -20,6 +21,9 @@ __all__ = [
     "RememberOptions",
     "RecallFilters",
     "RecallOptions",
+    # Knowledge graph types
+    "LinkType",
+    "MemoryLink",
     # Error types
     "MnemotreeError",
     "StoreError",

--- a/src/mnemotree/analysis/models.py
+++ b/src/mnemotree/analysis/models.py
@@ -29,7 +29,6 @@ class MemoryClassificationResult(BaseModel):
 
 
 class EmotionAnalysisResult(BaseModel):
-    # emotions: Union[List[EmotionCategory], List[str]] = Field(description=f"List of emotions, possible values: {[e.value for e in EmotionCategory]}")
     emotions: list[str] = Field(
         description=f"List of emotions, possible values: {[e.value for e in EmotionCategory]}"
     )

--- a/src/mnemotree/core/builder.py
+++ b/src/mnemotree/core/builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
+from pathlib import Path
 from typing import Any, Literal  # noqa: F401 — Any used for adaptive_decay type
 
 from langchain_core.embeddings.embeddings import Embeddings
@@ -23,6 +24,8 @@ from .memory import (
 from .models import MemoryItem
 from .scoring import MemoryScoring
 
+_DEFAULT_DB_PATH = ".mnemotree/mnemotree.sqlite"
+
 
 class MemoryCoreBuilder:
     """Fluent builder for configuring MemoryCore without a long constructor signature."""
@@ -38,7 +41,36 @@ class MemoryCoreBuilder:
         self._ingestion_config = IngestionConfig()
 
     @classmethod
-    def lite(cls, store: MemoryCRUDStore) -> MemoryCoreBuilder:
+    def default(
+        cls,
+        db_path: str | Path = _DEFAULT_DB_PATH,
+        *,
+        collection_name: str = "memories",
+    ) -> MemoryCoreBuilder:
+        """Zero-config builder using SQLiteVecMemoryStore (no external infra needed).
+
+        Args:
+            db_path: Path to SQLite database file.
+            collection_name: Name of the memory collection.
+
+        Returns:
+            A builder pre-configured in lite mode with an SQLite store.
+        """
+        from ..store.sqlite_vec_store import SQLiteVecMemoryStore
+
+        store = SQLiteVecMemoryStore(db_path=db_path, collection_name=collection_name)
+        return cls(store).with_mode("lite")
+
+    @classmethod
+    def lite(cls, store: MemoryCRUDStore | None = None, **kwargs: Any) -> MemoryCoreBuilder:
+        """Create a lite-mode builder.
+
+        If *store* is ``None``, falls back to :meth:`default` using
+        ``SQLiteVecMemoryStore`` so callers can write
+        ``MemoryCoreBuilder.lite().build()`` with zero configuration.
+        """
+        if store is None:
+            return cls.default(**kwargs)
         return cls(store).with_mode("lite")
 
     @classmethod

--- a/src/mnemotree/core/memory.py
+++ b/src/mnemotree/core/memory.py
@@ -974,7 +974,7 @@ class MemoryCore:
         if not isinstance(self.store, SupportsKnowledgeGraph):
             raise RuntimeError(
                 f"Store {type(self.store).__name__} does not support knowledge graph operations. "
-                "Use Neo4jMemoryStore or SQLiteGraphStore."
+                "Use Neo4jMemoryStore or SQLiteVecMemoryStore."
             )
 
         return await self.store.create_link(
@@ -984,6 +984,63 @@ class MemoryCore:
             context=context,
             bidirectional=bidirectional,
         )
+
+    async def get_links(
+        self,
+        memory_id: str,
+        *,
+        direction: Literal["outgoing", "incoming", "both"] = "both",
+        link_types: list[LinkType] | None = None,
+        min_strength: float = 0.0,
+    ) -> list[MemoryLink]:
+        """
+        Get all links for a memory.
+
+        Args:
+            memory_id: ID of the memory
+            direction: Which links to retrieve (outgoing/incoming/both)
+            link_types: Optional filter for specific link types
+            min_strength: Minimum link strength threshold
+
+        Returns:
+            List of MemoryLink objects
+
+        Raises:
+            RuntimeError: If store doesn't support knowledge graph operations
+        """
+        if not isinstance(self.store, SupportsKnowledgeGraph):
+            raise RuntimeError(
+                f"Store {type(self.store).__name__} does not support knowledge graph operations. "
+                "Use Neo4jMemoryStore or SQLiteVecMemoryStore."
+            )
+
+        return await self.store.get_links(
+            memory_id,
+            direction=direction,
+            link_types=link_types,
+            min_strength=min_strength,
+        )
+
+    async def delete_link(self, link_id: str) -> bool:
+        """
+        Delete a link by ID.
+
+        Args:
+            link_id: ID of the link to delete
+
+        Returns:
+            True if successful, False if link not found
+
+        Raises:
+            RuntimeError: If store doesn't support knowledge graph operations
+        """
+        if not isinstance(self.store, SupportsKnowledgeGraph):
+            raise RuntimeError(
+                f"Store {type(self.store).__name__} does not support knowledge graph operations. "
+                "Use Neo4jMemoryStore or SQLiteVecMemoryStore."
+            )
+
+        return await self.store.delete_link(link_id)
 
     async def get_backlinks(
         self,

--- a/src/mnemotree/core/models.py
+++ b/src/mnemotree/core/models.py
@@ -219,7 +219,6 @@ class MemoryItem(BaseModel):
     # Emotional Analysis - # TODO: Consider using a separate EmotionalContext class, currently flattened
     emotional_valence: float | None = Field(None, ge=-1.0, le=1.0)  # -1 to 1
     emotional_arousal: float | None = Field(None, ge=0.0, le=1.0)  # 0 to 1
-    # emotions: Optional[Union[List[EmotionCategory], List[str]]] = Field(default_factory=list)
     emotions: list[str] = Field(default_factory=list)
 
     # Connections - # TODO: Consider using a separate Connections class, currently flattened

--- a/src/mnemotree/mcp/server.py
+++ b/src/mnemotree/mcp/server.py
@@ -210,30 +210,42 @@ async def _get_memory_core() -> MemoryCore:
         if _memory_core is not None:
             return _memory_core
 
-        persist_dir = os.getenv("MNEMOTREE_MCP_PERSIST_DIR", ".mnemotree/chromadb")
+        persist_dir = os.getenv("MNEMOTREE_MCP_PERSIST_DIR", ".mnemotree/mnemotree.sqlite")
         collection_name = os.getenv("MNEMOTREE_MCP_COLLECTION", "memories")
+
+        # Support legacy ChromaDB via env vars, otherwise default to SQLite (zero-infra).
         chroma_host = os.getenv("MNEMOTREE_MCP_CHROMA_HOST")
         chroma_port = os.getenv("MNEMOTREE_MCP_CHROMA_PORT")
-        chroma_ssl = _env_bool("MNEMOTREE_MCP_CHROMA_SSL", False)
+        store_backend = os.getenv("MNEMOTREE_MCP_STORE_BACKEND", "sqlite")
 
-        try:
-            from mnemotree.store import ChromaMemoryStore
-        except ModuleNotFoundError as exc:
-            raise ModuleNotFoundError(
-                "ChromaMemoryStore is required for the MCP server. "
-                "Install with `mnemotree[mcp_server]`."
-            ) from exc
+        if chroma_host and chroma_port or store_backend.lower() == "chroma":
+            try:
+                from mnemotree.store import ChromaMemoryStore
+            except ModuleNotFoundError as exc:
+                raise ModuleNotFoundError(
+                    "ChromaMemoryStore requires optional dependencies. "
+                    "Install with `pip install mnemotree[chroma]`."
+                ) from exc
 
-        if chroma_host and chroma_port:
-            store = ChromaMemoryStore(
-                host=chroma_host,
-                port=int(chroma_port),
-                ssl=chroma_ssl,
-                collection_name=collection_name,
-            )
+            chroma_ssl = _env_bool("MNEMOTREE_MCP_CHROMA_SSL", False)
+            if chroma_host and chroma_port:
+                store = ChromaMemoryStore(
+                    host=chroma_host,
+                    port=int(chroma_port),
+                    ssl=chroma_ssl,
+                    collection_name=collection_name,
+                )
+            else:
+                chroma_dir = os.getenv("MNEMOTREE_MCP_PERSIST_DIR", ".mnemotree/chromadb")
+                store = ChromaMemoryStore(
+                    persist_directory=chroma_dir,
+                    collection_name=collection_name,
+                )
         else:
-            store = ChromaMemoryStore(
-                persist_directory=persist_dir,
+            from mnemotree.store.sqlite_vec_store import SQLiteVecMemoryStore
+
+            store = SQLiteVecMemoryStore(
+                db_path=persist_dir,
                 collection_name=collection_name,
             )
 

--- a/src/mnemotree/mcp/server.py
+++ b/src/mnemotree/mcp/server.py
@@ -14,6 +14,7 @@ from mnemotree.core.memory import (
 )
 from mnemotree.core.models import MemoryItem, MemoryType, coerce_datetime
 from mnemotree.ner import create_ner
+from mnemotree.store.base import BaseMemoryStore
 from mnemotree.store.protocols import SupportsMemoryListing
 
 _memory_lock = asyncio.Lock()
@@ -218,6 +219,7 @@ async def _get_memory_core() -> MemoryCore:
         chroma_port = os.getenv("MNEMOTREE_MCP_CHROMA_PORT")
         store_backend = os.getenv("MNEMOTREE_MCP_STORE_BACKEND", "sqlite")
 
+        store: BaseMemoryStore
         if chroma_host and chroma_port or store_backend.lower() == "chroma":
             try:
                 from mnemotree.store import ChromaMemoryStore

--- a/src/mnemotree/store/neo4j_store.py
+++ b/src/mnemotree/store/neo4j_store.py
@@ -1282,7 +1282,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                 async for record in result:
                     node_data = dict(record["source"])
                     try:
-                        memory = parse_neo4j_node_data(node_data)
+                        memory = MemoryItem(**parse_neo4j_node_data(node_data))
                         memories.append(memory)
                     except (ValidationError, ValueError) as e:
                         logger.warning(
@@ -1363,7 +1363,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                     rels = record["rels"]
 
                     try:
-                        memory = parse_neo4j_node_data(node_data)
+                        memory = MemoryItem(**parse_neo4j_node_data(node_data))
                         path_links = []
                         for r in rels:
                             metadata_str = r.get("metadata", "{}")
@@ -1459,7 +1459,7 @@ class Neo4jMemoryStore(BaseMemoryStore):
                 # Skip first node (source), include others
                 for _i, (node, rel) in enumerate(zip(nodes[1:], rels, strict=False)):
                     node_data = dict(node)
-                    memory = parse_neo4j_node_data(node_data)
+                    memory = MemoryItem(**parse_neo4j_node_data(node_data))
 
                     metadata_str = rel.get("metadata", "{}")
                     link = MemoryLink(

--- a/src/mnemotree/store/sqlite_vec_store.py
+++ b/src/mnemotree/store/sqlite_vec_store.py
@@ -6,17 +6,18 @@ import re
 import sqlite3
 import time
 from asyncio import Lock
+from collections import deque
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 try:
     import sqlite_vec
 except ImportError:  # pragma: no cover - optional dependency
     sqlite_vec = None
 
-from ..core.models import MemoryItem
+from ..core.models import LinkType, MemoryItem, MemoryLink
 from ..core.query import MemoryQuery
-from ..utils.serialization import json_loads_dict
+from ..utils.serialization import json_dumps_safe, json_loads_dict
 from ._filters import build_sqlite_filter_clauses, normalize_filter_value
 from ._queries import build_entity_set
 from ._records import sqlite_memory_from_row, sqlite_record_from_memory
@@ -24,6 +25,7 @@ from ._schema import create_sqlite_schema, ensure_sqlite_vector_table
 from .base import BaseMemoryStore
 from .logging import elapsed_ms, store_log_context
 from .query_builders import UnsupportedQueryError
+from .serialization import serialize_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,7 @@ class SQLiteVecMemoryStore(BaseMemoryStore):
         self._vector_table = f"{collection_name}_vectors"
         self._meta_table = f"{collection_name}_meta"
         self._entity_table = f"{collection_name}_entity_index"
+        self._link_table = f"{collection_name}_links"
         self._entity_index_version = 1
         self._conn: sqlite3.Connection | None = None
         self._embedding_dim = embedding_dim
@@ -124,6 +127,44 @@ class SQLiteVecMemoryStore(BaseMemoryStore):
             f"""
             CREATE INDEX IF NOT EXISTS "{self._entity_table}_name_idx"
             ON "{self._entity_table}" (normalized_name)
+            """
+        )
+        # Knowledge graph link table
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS "{self._link_table}" (
+                link_id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                link_type TEXT NOT NULL,
+                strength REAL NOT NULL DEFAULT 1.0,
+                context TEXT,
+                created_at TEXT NOT NULL,
+                last_accessed TEXT NOT NULL,
+                access_count INTEGER DEFAULT 0,
+                created_by TEXT DEFAULT 'user',
+                similarity_score REAL,
+                metadata TEXT,
+                UNIQUE(source_id, target_id, link_type)
+            )
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS "{self._link_table}_source_idx"
+            ON "{self._link_table}" (source_id)
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS "{self._link_table}_target_idx"
+            ON "{self._link_table}" (target_id)
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS "{self._link_table}_type_idx"
+            ON "{self._link_table}" (link_type)
             """
         )
         conn.commit()
@@ -549,6 +590,581 @@ class SQLiteVecMemoryStore(BaseMemoryStore):
                 ),
             )
             raise
+
+    # -- Knowledge Graph Operations --
+
+    def _link_from_row(self, row: sqlite3.Row) -> MemoryLink:
+        metadata_str = row["metadata"]
+        return MemoryLink(
+            link_id=row["link_id"],
+            source_id=row["source_id"],
+            target_id=row["target_id"],
+            link_type=LinkType(row["link_type"]),
+            strength=row["strength"],
+            context=row["context"],
+            created_at=row["created_at"],
+            last_accessed=row["last_accessed"],
+            access_count=row["access_count"],
+            created_by=row["created_by"],
+            similarity_score=row["similarity_score"],
+            metadata=json.loads(metadata_str) if metadata_str else {},
+        )
+
+    async def create_link(
+        self,
+        source_id: str,
+        target_id: str,
+        link_type: LinkType,
+        *,
+        strength: float = 1.0,
+        context: str | None = None,
+        bidirectional: bool = False,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryLink:
+        await self.initialize()
+        start = time.perf_counter()
+
+        link = MemoryLink(
+            source_id=source_id,
+            target_id=target_id,
+            link_type=link_type,
+            strength=strength,
+            context=context,
+            metadata=metadata or {},
+        )
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                now = serialize_datetime(link.created_at)
+                meta_json = json_dumps_safe(link.metadata)
+
+                conn.execute(
+                    f'INSERT OR REPLACE INTO "{self._link_table}" '
+                    "(link_id, source_id, target_id, link_type, strength, context, "
+                    "created_at, last_accessed, access_count, created_by, "
+                    "similarity_score, metadata) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        link.link_id,
+                        source_id,
+                        target_id,
+                        link_type.value,
+                        strength,
+                        context,
+                        now,
+                        now,
+                        0,
+                        link.created_by,
+                        link.similarity_score,
+                        meta_json,
+                    ),
+                )
+
+                if bidirectional:
+                    reverse = MemoryLink(
+                        source_id=target_id,
+                        target_id=source_id,
+                        link_type=link_type,
+                        strength=strength,
+                        context=context,
+                        metadata=metadata or {},
+                    )
+                    conn.execute(
+                        f'INSERT OR REPLACE INTO "{self._link_table}" '
+                        "(link_id, source_id, target_id, link_type, strength, context, "
+                        "created_at, last_accessed, access_count, created_by, "
+                        "similarity_score, metadata) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            reverse.link_id,
+                            target_id,
+                            source_id,
+                            link_type.value,
+                            strength,
+                            context,
+                            serialize_datetime(reverse.created_at),
+                            serialize_datetime(reverse.last_accessed),
+                            0,
+                            reverse.created_by,
+                            reverse.similarity_score,
+                            meta_json,
+                        ),
+                    )
+
+                conn.commit()
+                logger.info(
+                    "Created link %s from %s to %s",
+                    link.link_id,
+                    source_id,
+                    target_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                return link
+            except sqlite3.Error:
+                conn.rollback()
+                logger.exception(
+                    "Failed to create link from %s to %s",
+                    source_id,
+                    target_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
+
+    async def get_links(
+        self,
+        memory_id: str,
+        *,
+        direction: Literal["outgoing", "incoming", "both"] = "both",
+        link_types: list[LinkType] | None = None,
+        min_strength: float = 0.0,
+    ) -> list[MemoryLink]:
+        await self.initialize()
+        start = time.perf_counter()
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                where_clauses: list[str] = []
+                params: list[Any] = []
+
+                if direction == "outgoing":
+                    where_clauses.append("source_id = ?")
+                    params.append(memory_id)
+                elif direction == "incoming":
+                    where_clauses.append("target_id = ?")
+                    params.append(memory_id)
+                else:
+                    where_clauses.append("(source_id = ? OR target_id = ?)")
+                    params.extend([memory_id, memory_id])
+
+                where_clauses.append("strength >= ?")
+                params.append(min_strength)
+
+                if link_types:
+                    placeholders = ", ".join("?" for _ in link_types)
+                    where_clauses.append(f"link_type IN ({placeholders})")
+                    params.extend(lt.value for lt in link_types)
+
+                where_sql = " AND ".join(where_clauses)
+                rows = conn.execute(
+                    f'SELECT * FROM "{self._link_table}" WHERE {where_sql}',
+                    params,
+                ).fetchall()
+
+                links = [self._link_from_row(row) for row in rows]
+                logger.info(
+                    "Retrieved %d links for memory %s",
+                    len(links),
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                return links
+            except sqlite3.Error:
+                logger.exception(
+                    "Failed to get links for memory %s",
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
+
+    async def get_backlinks(
+        self,
+        memory_id: str,
+        *,
+        link_types: list[LinkType] | None = None,
+    ) -> list[MemoryItem]:
+        await self.initialize()
+        start = time.perf_counter()
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                where_clauses = ["l.target_id = ?"]
+                params: list[Any] = [memory_id]
+
+                if link_types:
+                    placeholders = ", ".join("?" for _ in link_types)
+                    where_clauses.append(f"l.link_type IN ({placeholders})")
+                    params.extend(lt.value for lt in link_types)
+
+                where_sql = " AND ".join(where_clauses)
+                sql = (
+                    f'SELECT m.* FROM "{self.collection_name}" m '
+                    f'JOIN "{self._link_table}" l ON l.source_id = m.memory_id '
+                    f"WHERE {where_sql}"
+                )
+                rows = conn.execute(sql, params).fetchall()
+                memories = [sqlite_memory_from_row(row) for row in rows]
+
+                logger.info(
+                    "Retrieved %d backlinks for memory %s",
+                    len(memories),
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                return memories
+            except sqlite3.Error:
+                logger.exception(
+                    "Failed to get backlinks for memory %s",
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
+
+    async def traverse_graph(
+        self,
+        start_id: str,
+        *,
+        max_depth: int = 3,
+        link_types: list[LinkType] | None = None,
+        strategy: Literal["bfs", "dfs"] = "bfs",
+    ) -> list[tuple[MemoryItem, int, list[MemoryLink]]]:
+        await self.initialize()
+        start_time = time.perf_counter()
+        max_depth = min(max_depth, 5)
+
+        type_values = {lt.value for lt in link_types} if link_types else None
+
+        result: list[tuple[MemoryItem, int, list[MemoryLink]]] = []
+        visited: set[str] = {start_id}
+
+        # (current_memory_id, current_depth, path_links)
+        frontier: deque[tuple[str, int, list[MemoryLink]]] = deque()
+        frontier.append((start_id, 0, []))
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                while frontier:
+                    if strategy == "bfs":
+                        current_id, depth, path_links = frontier.popleft()
+                    else:
+                        current_id, depth, path_links = frontier.pop()
+
+                    if depth >= max_depth:
+                        continue
+
+                    # Get outgoing links from current node
+                    rows = conn.execute(
+                        f'SELECT * FROM "{self._link_table}" WHERE source_id = ?',
+                        (current_id,),
+                    ).fetchall()
+
+                    for row in rows:
+                        link = self._link_from_row(row)
+                        if type_values and link.link_type.value not in type_values:
+                            continue
+                        target_id = link.target_id
+                        if target_id in visited:
+                            continue
+                        visited.add(target_id)
+
+                        # Fetch the target memory
+                        mem_row = conn.execute(
+                            f'SELECT * FROM "{self.collection_name}" WHERE memory_id = ?',
+                            (target_id,),
+                        ).fetchone()
+                        if not mem_row:
+                            continue
+                        memory = sqlite_memory_from_row(mem_row)
+                        new_path = path_links + [link]
+                        result.append((memory, depth + 1, new_path))
+                        frontier.append((target_id, depth + 1, new_path))
+
+                logger.info(
+                    "Traversed graph from %s, found %d nodes",
+                    start_id,
+                    len(result),
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start_time),
+                    ),
+                )
+                return result
+            except sqlite3.Error:
+                logger.exception(
+                    "Failed to traverse graph from %s",
+                    start_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start_time),
+                    ),
+                )
+                raise
+
+    async def find_path(
+        self,
+        source_id: str,
+        target_id: str,
+        *,
+        max_depth: int = 5,
+    ) -> list[tuple[MemoryItem, MemoryLink]] | None:
+        await self.initialize()
+        start_time = time.perf_counter()
+        max_depth = min(max_depth, 10)
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                # BFS to find shortest path
+                visited: set[str] = {source_id}
+                # Each entry: (current_id, path_of_(memory_id, link) pairs)
+                queue: deque[tuple[str, list[tuple[str, MemoryLink]]]] = deque()
+                queue.append((source_id, []))
+
+                while queue:
+                    current_id, path = queue.popleft()
+                    if len(path) >= max_depth:
+                        continue
+
+                    rows = conn.execute(
+                        f'SELECT * FROM "{self._link_table}" WHERE source_id = ?',
+                        (current_id,),
+                    ).fetchall()
+
+                    for row in rows:
+                        link = self._link_from_row(row)
+                        next_id = link.target_id
+                        if next_id in visited:
+                            continue
+                        visited.add(next_id)
+
+                        new_path = path + [(next_id, link)]
+
+                        if next_id == target_id:
+                            # Build result: fetch memories for each step
+                            result: list[tuple[MemoryItem, MemoryLink]] = []
+                            for mem_id, step_link in new_path:
+                                mem_row = conn.execute(
+                                    f'SELECT * FROM "{self.collection_name}" WHERE memory_id = ?',
+                                    (mem_id,),
+                                ).fetchone()
+                                if mem_row:
+                                    result.append((sqlite_memory_from_row(mem_row), step_link))
+                            logger.info(
+                                "Found path from %s to %s with %d hops",
+                                source_id,
+                                target_id,
+                                len(result),
+                                extra=store_log_context(
+                                    self.store_type,
+                                    duration_ms=elapsed_ms(start_time),
+                                ),
+                            )
+                            return result
+
+                        queue.append((next_id, new_path))
+
+                return None
+            except sqlite3.Error:
+                logger.exception(
+                    "Failed to find path from %s to %s",
+                    source_id,
+                    target_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start_time),
+                    ),
+                )
+                raise
+
+    async def suggest_links(
+        self,
+        memory_id: str,
+        *,
+        limit: int = 10,
+        min_similarity: float = 0.7,
+        use_llm: bool = False,
+    ) -> list[tuple[MemoryItem, LinkType, float, str | None]]:
+        await self.initialize()
+        start = time.perf_counter()
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                # Get the source memory's embedding
+                mem_row = conn.execute(
+                    f'SELECT id FROM "{self.collection_name}" WHERE memory_id = ?',
+                    (memory_id,),
+                ).fetchone()
+                if not mem_row or self._embedding_dim is None:
+                    return []
+
+                source_rowid = mem_row["id"]
+
+                # Get embedding for source memory
+                vec_row = conn.execute(
+                    f'SELECT embedding FROM "{self._vector_table}" WHERE rowid = ?',
+                    (source_rowid,),
+                ).fetchone()
+                if not vec_row:
+                    return []
+
+                source_embedding = vec_row["embedding"]
+
+                # Get already-linked memory IDs to exclude
+                linked_rows = conn.execute(
+                    f'SELECT target_id FROM "{self._link_table}" WHERE source_id = ? '
+                    f'UNION SELECT source_id FROM "{self._link_table}" WHERE target_id = ?',
+                    (memory_id, memory_id),
+                ).fetchall()
+                excluded_ids = {memory_id} | {
+                    row["target_id"] if "target_id" in row else row["source_id"]
+                    for row in linked_rows
+                }
+
+                # Find similar memories using vector search
+                # sqlite-vec distance() returns L2 distance; lower = more similar
+                # We fetch extra candidates and filter out linked ones
+                fetch_limit = limit + len(excluded_ids) + 5
+                similar_rows = conn.execute(
+                    f"SELECT m.*, distance(v.embedding, ?) AS dist "
+                    f'FROM "{self._vector_table}" v '
+                    f'JOIN "{self.collection_name}" m ON m.id = v.rowid '
+                    "ORDER BY dist "
+                    "LIMIT ?",
+                    (source_embedding, fetch_limit),
+                ).fetchall()
+
+                suggestions: list[tuple[MemoryItem, LinkType, float, str | None]] = []
+                for row in similar_rows:
+                    mid = row["memory_id"]
+                    if mid in excluded_ids:
+                        continue
+                    # Convert L2 distance to a 0-1 similarity score
+                    # Using 1/(1+dist) as a simple conversion
+                    dist = row["dist"]
+                    similarity = 1.0 / (1.0 + dist)
+                    if similarity < min_similarity:
+                        continue
+                    memory = sqlite_memory_from_row(row)
+                    suggestions.append((memory, LinkType.SIMILAR_TO, similarity, None))
+                    if len(suggestions) >= limit:
+                        break
+
+                logger.info(
+                    "Suggested %d links for memory %s",
+                    len(suggestions),
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                return suggestions
+            except sqlite3.Error:
+                logger.exception(
+                    "Failed to suggest links for memory %s",
+                    memory_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        memory_id=memory_id,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
+
+    async def update_link_strength(
+        self,
+        link_id: str,
+        strength: float,
+    ) -> bool:
+        await self.initialize()
+        start = time.perf_counter()
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                cursor = conn.execute(
+                    f'UPDATE "{self._link_table}" SET strength = ? WHERE link_id = ?',
+                    (strength, link_id),
+                )
+                conn.commit()
+                success = cursor.rowcount > 0
+                if success:
+                    logger.info(
+                        "Updated link strength for %s to %f",
+                        link_id,
+                        strength,
+                        extra=store_log_context(
+                            self.store_type,
+                            duration_ms=elapsed_ms(start),
+                        ),
+                    )
+                return success
+            except sqlite3.Error:
+                conn.rollback()
+                logger.exception(
+                    "Failed to update link strength for %s",
+                    link_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
+
+    async def delete_link(
+        self,
+        link_id: str,
+    ) -> bool:
+        await self.initialize()
+        start = time.perf_counter()
+
+        async with self._lock:
+            conn = self._require_conn()
+            try:
+                cursor = conn.execute(
+                    f'DELETE FROM "{self._link_table}" WHERE link_id = ?',
+                    (link_id,),
+                )
+                conn.commit()
+                success = cursor.rowcount > 0
+                if success:
+                    logger.info(
+                        "Deleted link %s",
+                        link_id,
+                        extra=store_log_context(
+                            self.store_type,
+                            duration_ms=elapsed_ms(start),
+                        ),
+                    )
+                return success
+            except sqlite3.Error:
+                conn.rollback()
+                logger.exception(
+                    "Failed to delete link %s",
+                    link_id,
+                    extra=store_log_context(
+                        self.store_type,
+                        duration_ms=elapsed_ms(start),
+                    ),
+                )
+                raise
 
     async def close(self) -> None:
         if self._conn is not None:

--- a/src/mnemotree/store/sqlite_vec_store.py
+++ b/src/mnemotree/store/sqlite_vec_store.py
@@ -1027,26 +1027,24 @@ class SQLiteVecMemoryStore(BaseMemoryStore):
 
                 # Get already-linked memory IDs to exclude
                 linked_rows = conn.execute(
-                    f'SELECT target_id FROM "{self._link_table}" WHERE source_id = ? '
-                    f'UNION SELECT source_id FROM "{self._link_table}" WHERE target_id = ?',
+                    f'SELECT target_id AS linked_id FROM "{self._link_table}" WHERE source_id = ? '
+                    f'UNION SELECT source_id AS linked_id FROM "{self._link_table}" WHERE target_id = ?',
                     (memory_id, memory_id),
                 ).fetchall()
-                excluded_ids = {memory_id} | {
-                    row["target_id"] if "target_id" in row else row["source_id"]
-                    for row in linked_rows
-                }
+                excluded_ids = {memory_id} | {row[0] for row in linked_rows}
 
                 # Find similar memories using vector search
                 # sqlite-vec distance() returns L2 distance; lower = more similar
                 # We fetch extra candidates and filter out linked ones
                 fetch_limit = limit + len(excluded_ids) + 5
+                vector_blob = source_embedding
                 similar_rows = conn.execute(
-                    f"SELECT m.*, distance(v.embedding, ?) AS dist "
+                    f"SELECT m.*, v.distance AS dist "
                     f'FROM "{self._vector_table}" v '
                     f'JOIN "{self.collection_name}" m ON m.id = v.rowid '
-                    "ORDER BY dist "
-                    "LIMIT ?",
-                    (source_embedding, fetch_limit),
+                    "WHERE v.embedding MATCH ? AND k = ? "
+                    "ORDER BY v.distance",
+                    (vector_blob, fetch_limit),
                 ).fetchall()
 
                 suggestions: list[tuple[MemoryItem, LinkType, float, str | None]] = []

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -470,22 +470,23 @@ async def test_get_memory_core_remote_store_and_ner(
 
 
 @pytest.mark.asyncio
-async def test_get_memory_core_persist_dir(monkeypatch, memory_core_env_setup):
+async def test_get_memory_core_persist_dir(monkeypatch, memory_core_env_setup, tmp_path):
     def _fake_create_ner(*args, **kwargs) -> None:
         raise AssertionError("create_ner should not be called without backend config")
 
     monkeypatch.setattr(server, "create_ner", _fake_create_ner)
 
+    db_path = str(tmp_path / "mnemotree.sqlite")
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_HOST", raising=False)
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_PORT", raising=False)
-    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", "/tmp/mnemotree.sqlite")
+    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", db_path)
     monkeypatch.setenv("MNEMOTREE_MCP_COLLECTION", "memories_local")
 
     core = await server._get_memory_core()
 
     # Default path now uses SQLiteVecMemoryStore
     assert core.store.kwargs == {
-        "db_path": "/tmp/mnemotree.sqlite",
+        "db_path": db_path,
         "collection_name": "memories_local",
     }
     mode_defaults = core.kwargs["mode_defaults"]
@@ -498,14 +499,14 @@ async def test_get_memory_core_persist_dir(monkeypatch, memory_core_env_setup):
 
 
 @pytest.mark.asyncio
-async def test_get_memory_core_retrieval_config_bm25(monkeypatch, memory_core_env_setup):
+async def test_get_memory_core_retrieval_config_bm25(monkeypatch, memory_core_env_setup, tmp_path):
     def _fake_create_ner(*args, **kwargs) -> None:
         raise AssertionError("create_ner should not be called")
 
     monkeypatch.setattr(server, "create_ner", _fake_create_ner)
 
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_HOST", raising=False)
-    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", "/tmp/test")
+    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", str(tmp_path / "test.sqlite"))
     monkeypatch.setenv("MNEMOTREE_MCP_ENABLE_BM25", "1")
 
     core = await server._get_memory_core()
@@ -517,14 +518,16 @@ async def test_get_memory_core_retrieval_config_bm25(monkeypatch, memory_core_en
 
 
 @pytest.mark.asyncio
-async def test_get_memory_core_retrieval_config_bm25_disabled(monkeypatch, memory_core_env_setup):
+async def test_get_memory_core_retrieval_config_bm25_disabled(
+    monkeypatch, memory_core_env_setup, tmp_path
+):
     def _fake_create_ner(*args, **kwargs) -> None:
         raise AssertionError("create_ner should not be called")
 
     monkeypatch.setattr(server, "create_ner", _fake_create_ner)
 
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_HOST", raising=False)
-    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", "/tmp/test")
+    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", str(tmp_path / "test.sqlite"))
     monkeypatch.setenv("MNEMOTREE_MCP_ENABLE_BM25", "0")
 
     core = await server._get_memory_core()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,10 +88,16 @@ def dummy_memory_core_class():
 @pytest.fixture
 def memory_core_env_setup(monkeypatch, dummy_store_class, dummy_memory_core_class):
     """Common setup for memory core environment tests."""
+    # Patch ChromaDB store for backward-compatibility tests
     fake_store_module = types.ModuleType("mnemotree.store")
     fake_store_module.ChromaMemoryStore = dummy_store_class
-
     monkeypatch.setitem(sys.modules, "mnemotree.store", fake_store_module)
+
+    # Patch SQLite store for default-path tests
+    fake_sqlite_module = types.ModuleType("mnemotree.store.sqlite_vec_store")
+    fake_sqlite_module.SQLiteVecMemoryStore = dummy_store_class
+    monkeypatch.setitem(sys.modules, "mnemotree.store.sqlite_vec_store", fake_sqlite_module)
+
     monkeypatch.setattr(server, "MemoryCore", dummy_memory_core_class)
     monkeypatch.setattr(server, "_memory_core", None)
 
@@ -472,14 +478,15 @@ async def test_get_memory_core_persist_dir(monkeypatch, memory_core_env_setup):
 
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_HOST", raising=False)
     monkeypatch.delenv("MNEMOTREE_MCP_CHROMA_PORT", raising=False)
-    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", "/tmp/mnemotree")
-    monkeypatch.setenv("MNEMOTREE_MCP_COLLECTION", "memories-local")
+    monkeypatch.setenv("MNEMOTREE_MCP_PERSIST_DIR", "/tmp/mnemotree.sqlite")
+    monkeypatch.setenv("MNEMOTREE_MCP_COLLECTION", "memories_local")
 
     core = await server._get_memory_core()
 
+    # Default path now uses SQLiteVecMemoryStore
     assert core.store.kwargs == {
-        "persist_directory": "/tmp/mnemotree",
-        "collection_name": "memories-local",
+        "db_path": "/tmp/mnemotree.sqlite",
+        "collection_name": "memories_local",
     }
     mode_defaults = core.kwargs["mode_defaults"]
     ner_config = core.kwargs["ner_config"]
@@ -569,8 +576,10 @@ async def test_get_memory_core_import_error(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", _blocked_import)
     monkeypatch.setattr(server, "_memory_core", None)
+    # Explicitly request chroma backend to trigger the ChromaDB import path
+    monkeypatch.setenv("MNEMOTREE_MCP_STORE_BACKEND", "chroma")
 
-    with pytest.raises(ModuleNotFoundError, match="ChromaMemoryStore is required"):
+    with pytest.raises(ModuleNotFoundError, match="ChromaMemoryStore requires optional"):
         await server._get_memory_core()
 
 

--- a/tests/store/test_sqlite_knowledge_graph.py
+++ b/tests/store/test_sqlite_knowledge_graph.py
@@ -1,0 +1,348 @@
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from mnemotree.core.models import LinkType, MemoryItem, MemoryType
+from mnemotree.store.sqlite_vec_store import SQLiteVecMemoryStore
+
+sqlite_vec = pytest.importorskip("sqlite_vec")
+
+try:
+    conn = sqlite3.connect(":memory:")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.close()
+except sqlite3.Error:
+    pytest.skip("sqlite-vec extension is not loadable", allow_module_level=True)
+
+EMBEDDING_DIM = 8
+
+
+def _make_memory(memory_id: str, content: str, embedding: list[float] | None = None) -> MemoryItem:
+    if embedding is None:
+        # Generate a simple deterministic embedding based on id
+        base = hash(memory_id) % 100 / 100.0
+        embedding = [base + i * 0.01 for i in range(EMBEDDING_DIM)]
+    return MemoryItem(
+        memory_id=memory_id,
+        content=content,
+        memory_type=MemoryType.SEMANTIC,
+        importance=0.5,
+        timestamp=str(datetime.now(timezone.utc)),
+        embedding=embedding,
+    )
+
+
+@pytest.fixture
+async def store(tmp_path):
+    db_path = tmp_path / "test_kg.sqlite"
+    s = SQLiteVecMemoryStore(db_path=db_path, embedding_dim=EMBEDDING_DIM)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+async def populated_store(store):
+    """Store with 3 memories: m1, m2, m3."""
+    m1 = _make_memory("m1", "First memory about Python")
+    m2 = _make_memory("m2", "Second memory about testing")
+    m3 = _make_memory("m3", "Third memory about databases")
+    await store.store_memory(m1)
+    await store.store_memory(m2)
+    await store.store_memory(m3)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_create_link(populated_store):
+    store = populated_store
+    link = await store.create_link(
+        "m1",
+        "m2",
+        LinkType.REFERENCES,
+        context="m1 references m2",
+    )
+    assert link.source_id == "m1"
+    assert link.target_id == "m2"
+    assert link.link_type == LinkType.REFERENCES
+    assert link.context == "m1 references m2"
+    assert link.strength == 1.0
+    assert link.link_id  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_create_bidirectional_link(populated_store):
+    store = populated_store
+    await store.create_link(
+        "m1",
+        "m2",
+        LinkType.SIMILAR_TO,
+        bidirectional=True,
+    )
+    # Should have the forward link
+    outgoing = await store.get_links("m1", direction="outgoing")
+    assert any(lk.target_id == "m2" and lk.link_type == LinkType.SIMILAR_TO for lk in outgoing)
+
+    # Should have the reverse link
+    outgoing_m2 = await store.get_links("m2", direction="outgoing")
+    assert any(lk.target_id == "m1" and lk.link_type == LinkType.SIMILAR_TO for lk in outgoing_m2)
+
+
+@pytest.mark.asyncio
+async def test_get_links_direction_filter(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m3", "m1", LinkType.SUPPORTS)
+
+    outgoing = await store.get_links("m1", direction="outgoing")
+    assert len(outgoing) == 1
+    assert outgoing[0].target_id == "m2"
+
+    incoming = await store.get_links("m1", direction="incoming")
+    assert len(incoming) == 1
+    assert incoming[0].source_id == "m3"
+
+    both = await store.get_links("m1", direction="both")
+    assert len(both) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_links_type_filter(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m1", "m3", LinkType.SUPPORTS)
+
+    refs_only = await store.get_links("m1", link_types=[LinkType.REFERENCES])
+    assert len(refs_only) == 1
+    assert refs_only[0].link_type == LinkType.REFERENCES
+
+    both_types = await store.get_links("m1", link_types=[LinkType.REFERENCES, LinkType.SUPPORTS])
+    assert len(both_types) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_links_strength_filter(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES, strength=0.3)
+    await store.create_link("m1", "m3", LinkType.SUPPORTS, strength=0.8)
+
+    strong_links = await store.get_links("m1", min_strength=0.5)
+    assert len(strong_links) == 1
+    assert strong_links[0].strength == 0.8
+
+
+@pytest.mark.asyncio
+async def test_get_backlinks(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m3", "m2", LinkType.SUPPORTS)
+
+    backlinks = await store.get_backlinks("m2")
+    assert len(backlinks) == 2
+    backlink_ids = {m.memory_id for m in backlinks}
+    assert backlink_ids == {"m1", "m3"}
+
+
+@pytest.mark.asyncio
+async def test_get_backlinks_type_filter(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m3", "m2", LinkType.SUPPORTS)
+
+    refs_only = await store.get_backlinks("m2", link_types=[LinkType.REFERENCES])
+    assert len(refs_only) == 1
+    assert refs_only[0].memory_id == "m1"
+
+
+@pytest.mark.asyncio
+async def test_traverse_bfs(populated_store):
+    store = populated_store
+    # m1 -> m2 -> m3
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m2", "m3", LinkType.ELABORATES)
+
+    result = await store.traverse_graph("m1", max_depth=3, strategy="bfs")
+    assert len(result) == 2
+
+    # First hop should be m2
+    assert result[0][0].memory_id == "m2"
+    assert result[0][1] == 1  # depth
+    assert len(result[0][2]) == 1  # one link in path
+
+    # Second hop should be m3
+    assert result[1][0].memory_id == "m3"
+    assert result[1][1] == 2  # depth
+    assert len(result[1][2]) == 2  # two links in path
+
+
+@pytest.mark.asyncio
+async def test_traverse_dfs(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m2", "m3", LinkType.ELABORATES)
+
+    result = await store.traverse_graph("m1", max_depth=3, strategy="dfs")
+    # Should still find both nodes
+    found_ids = {r[0].memory_id for r in result}
+    assert found_ids == {"m2", "m3"}
+
+
+@pytest.mark.asyncio
+async def test_traverse_link_type_filter(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m1", "m3", LinkType.SUPPORTS)
+
+    result = await store.traverse_graph("m1", max_depth=2, link_types=[LinkType.REFERENCES])
+    assert len(result) == 1
+    assert result[0][0].memory_id == "m2"
+
+
+@pytest.mark.asyncio
+async def test_find_path(populated_store):
+    store = populated_store
+    # m1 -> m2 -> m3
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+    await store.create_link("m2", "m3", LinkType.ELABORATES)
+
+    path = await store.find_path("m1", "m3")
+    assert path is not None
+    assert len(path) == 2
+
+    # First step: m2 via the m1->m2 link
+    assert path[0][0].memory_id == "m2"
+    assert path[0][1].link_type == LinkType.REFERENCES
+
+    # Second step: m3 via the m2->m3 link
+    assert path[1][0].memory_id == "m3"
+    assert path[1][1].link_type == LinkType.ELABORATES
+
+
+@pytest.mark.asyncio
+async def test_find_path_no_connection(populated_store):
+    store = populated_store
+    # No links at all
+    path = await store.find_path("m1", "m3")
+    assert path is None
+
+
+@pytest.mark.asyncio
+async def test_find_path_direct(populated_store):
+    store = populated_store
+    await store.create_link("m1", "m2", LinkType.REFERENCES)
+
+    path = await store.find_path("m1", "m2")
+    assert path is not None
+    assert len(path) == 1
+    assert path[0][0].memory_id == "m2"
+
+
+@pytest.mark.asyncio
+async def test_suggest_links(tmp_path):
+    """Test that suggest_links returns candidates based on embedding similarity."""
+    db_path = tmp_path / "test_suggest.sqlite"
+    store = SQLiteVecMemoryStore(db_path=db_path, embedding_dim=EMBEDDING_DIM)
+    await store.initialize()
+
+    try:
+        # Create memories with similar embeddings
+        base_embed = [0.5] * EMBEDDING_DIM
+        similar_embed = [0.51] * EMBEDDING_DIM  # very close
+        different_embed = [0.0] * EMBEDDING_DIM  # far away
+
+        m1 = _make_memory("m1", "Base memory", embedding=base_embed)
+        m2 = _make_memory("m2", "Similar memory", embedding=similar_embed)
+        m3 = _make_memory("m3", "Different memory", embedding=different_embed)
+
+        await store.store_memory(m1)
+        await store.store_memory(m2)
+        await store.store_memory(m3)
+
+        suggestions = await store.suggest_links("m1", limit=5, min_similarity=0.5)
+
+        # m2 should be suggested (close embedding), m3 might not be (far away)
+        suggested_ids = {s[0].memory_id for s in suggestions}
+        assert "m2" in suggested_ids
+        # All suggestions should have SIMILAR_TO type
+        for _, link_type, confidence, _ in suggestions:
+            assert link_type == LinkType.SIMILAR_TO
+            assert 0.0 <= confidence <= 1.0
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_suggest_links_excludes_linked(tmp_path):
+    """Already-linked memories should be excluded from suggestions."""
+    db_path = tmp_path / "test_suggest_excl.sqlite"
+    store = SQLiteVecMemoryStore(db_path=db_path, embedding_dim=EMBEDDING_DIM)
+    await store.initialize()
+
+    try:
+        embed = [0.5] * EMBEDDING_DIM
+        m1 = _make_memory("m1", "Memory A", embedding=embed)
+        m2 = _make_memory("m2", "Memory B", embedding=[0.51] * EMBEDDING_DIM)
+        await store.store_memory(m1)
+        await store.store_memory(m2)
+
+        # Link m1 to m2
+        await store.create_link("m1", "m2", LinkType.REFERENCES)
+
+        # m2 should now be excluded from suggestions
+        suggestions = await store.suggest_links("m1", min_similarity=0.0)
+        suggested_ids = {s[0].memory_id for s in suggestions}
+        assert "m2" not in suggested_ids
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_update_link_strength(populated_store):
+    store = populated_store
+    link = await store.create_link("m1", "m2", LinkType.REFERENCES, strength=0.5)
+
+    success = await store.update_link_strength(link.link_id, 0.9)
+    assert success is True
+
+    # Verify the update
+    links = await store.get_links("m1", direction="outgoing")
+    assert len(links) == 1
+    assert links[0].strength == pytest.approx(0.9)
+
+
+@pytest.mark.asyncio
+async def test_update_link_strength_nonexistent(populated_store):
+    store = populated_store
+    success = await store.update_link_strength("nonexistent-link-id", 0.5)
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_delete_link(populated_store):
+    store = populated_store
+    link = await store.create_link("m1", "m2", LinkType.REFERENCES)
+
+    success = await store.delete_link(link.link_id)
+    assert success is True
+
+    # Verify deletion
+    links = await store.get_links("m1", direction="outgoing")
+    assert len(links) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_link_nonexistent(populated_store):
+    store = populated_store
+    success = await store.delete_link("nonexistent-link-id")
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_protocol_compliance(populated_store):
+    """Verify that SQLiteVecMemoryStore satisfies SupportsKnowledgeGraph protocol."""
+    from mnemotree.store.protocols import SupportsKnowledgeGraph
+
+    assert isinstance(populated_store, SupportsKnowledgeGraph)

--- a/tests/store/test_sqlite_knowledge_graph.py
+++ b/tests/store/test_sqlite_knowledge_graph.py
@@ -69,7 +69,7 @@ async def test_create_link(populated_store):
     assert link.target_id == "m2"
     assert link.link_type == LinkType.REFERENCES
     assert link.context == "m1 references m2"
-    assert link.strength == 1.0
+    assert link.strength == pytest.approx(1.0)
     assert link.link_id  # non-empty
 
 
@@ -131,7 +131,7 @@ async def test_get_links_strength_filter(populated_store):
 
     strong_links = await store.get_links("m1", min_strength=0.5)
     assert len(strong_links) == 1
-    assert strong_links[0].strength == 0.8
+    assert strong_links[0].strength == pytest.approx(0.8)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

- Add knowledge graph foundation: LinkType enum, MemoryLink model, and
  SupportsKnowledgeGraph protocol with 8 graph operations
- Implement full knowledge graph backend in SQLiteVecMemoryStore
(create/get/delete links, BFS/DFS traversal, shortest path,
similarity-based link suggestions)
- Implement Neo4j knowledge graph backend
- Add MemoryCore API wrappers: link(), get_links(), delete_link(),
get_backlinks(), explore(), find_connection()
- Make SQLite the default zero-infra store:
MemoryCoreBuilder.lite().build() works with no arguments, MCP server
defaults to SQLite (ChromaDB still available via env vars)
- Export LinkType and MemoryLink from top-level package

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new lint warnings (ruff)
- [ ] My changes pass static type checking (mypy)
