### PR TITLE
fix: resolve SonarCloud reliability issues (S1244, S7502)

### DIFF
--- a/src/mnemotree/core/memory.py
+++ b/src/mnemotree/core/memory.py
@@ -228,6 +228,7 @@ class MemoryCore:
         self.store = store
         self.default_user_id = default_user_id
         self.default_conversation_id = default_conversation_id
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
         # Conflict detection (bi-temporal invalidation)
         from .conflict import ConflictConfig, ConflictDetector
@@ -865,10 +866,14 @@ class MemoryCore:
         await asyncio.gather(*store_tasks)
 
         if self.auto_link_enabled and isinstance(self.store, SupportsKnowledgeGraph):
-            asyncio.create_task(self._auto_link_background(memory.memory_id))
+            task = asyncio.create_task(self._auto_link_background(memory.memory_id))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         if self.conflict_detection_enabled and self.conflict_detector is not None:
-            asyncio.create_task(self._detect_and_link_conflicts(memory))
+            task = asyncio.create_task(self._detect_and_link_conflicts(memory))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
     async def _merge_into(
         self,

--- a/tests/core/test_adaptive.py
+++ b/tests/core/test_adaptive.py
@@ -202,7 +202,7 @@ class TestFSRSEdgeCases:
         s = FSRSSchedule(memory_id="m1", repetition_count=10, stability_seconds=86400.0)
         s.schedule_next_review(grade=1)
         assert s.repetition_count == 0
-        assert s.stability_seconds == 60.0
+        assert s.stability_seconds == pytest.approx(60.0)
 
 
 class TestAdaptiveUpdateImportance:

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from mnemotree.core.models import LinkType, MemoryItem, MemoryLink, MemoryType, coerce_datetime
 
 
@@ -169,7 +171,7 @@ def test_decay_strength_clamps_negative_elapsed_time():
         decay_rate=0.01,
     )
     # Strength should remain unchanged (elapsed clamped to 0, decay_factor = 1.0)
-    assert link.strength == 0.8
+    assert link.strength == pytest.approx(0.8)
 
 
 def test_decay_strength_normal_decay():

--- a/tests/core/test_observer.py
+++ b/tests/core/test_observer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from mnemotree.core.models import MemoryItem, MemoryType
 from mnemotree.core.observer import (
     MemoryObserver,
@@ -138,8 +140,8 @@ class TestReflectorConfig:
     def test_defaults(self):
         config = ReflectorConfig()
         assert config.min_memories_for_consolidation == 10
-        assert config.consolidation_interval_hours == 24.0
-        assert config.conflict_similarity_threshold == 0.92
+        assert config.consolidation_interval_hours == pytest.approx(24.0)
+        assert config.conflict_similarity_threshold == pytest.approx(0.92)
 
 
 def _make_memory(content: str, embedding: list[float] | None = None) -> MemoryItem:
@@ -241,7 +243,7 @@ class TestObservation:
     def test_defaults(self):
         obs = Observation(content="test fact")
         assert obs.memory_type == MemoryType.EPISODIC
-        assert obs.importance == 0.5
+        assert obs.importance == pytest.approx(0.5)
         assert obs.source == "observer"
         assert obs.tags == []
 
@@ -254,6 +256,6 @@ class TestObservation:
             observation_date=now,
             tags=["preference"],
         )
-        assert obs.importance == 0.8
+        assert obs.importance == pytest.approx(0.8)
         assert obs.observation_date == now
         assert obs.tags == ["preference"]

--- a/tests/core/test_phase1_fields.py
+++ b/tests/core/test_phase1_fields.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timezone
 
+import pytest
+
 from mnemotree.core.models import LinkType, MemoryItem, MemoryType
 
 
@@ -189,8 +191,8 @@ class TestSQLiteSerialization:
         row = conn.execute('SELECT * FROM "t" LIMIT 1').fetchone()
         restored = sqlite_memory_from_row(row)
 
-        assert restored.confidence == 0.0
-        assert restored.fidelity == 0.0
+        assert restored.confidence == pytest.approx(0.0)
+        assert restored.fidelity == pytest.approx(0.0)
         conn.close()
 
 

--- a/tests/core/test_scoring_internal.py
+++ b/tests/core/test_scoring_internal.py
@@ -37,16 +37,16 @@ class TestKeywordOverlapScore:
         assert keyword_overlap_score(["python"], ["rust"]) == pytest.approx(0.0)
 
     def test_none_tags(self):
-        assert keyword_overlap_score(None, ["python"]) == 0.0
+        assert keyword_overlap_score(None, ["python"]) == pytest.approx(0.0)
 
     def test_none_keywords(self):
-        assert keyword_overlap_score(["python"], None) == 0.0
+        assert keyword_overlap_score(["python"], None) == pytest.approx(0.0)
 
     def test_empty_tags(self):
-        assert keyword_overlap_score([], ["python"]) == 0.0
+        assert keyword_overlap_score([], ["python"]) == pytest.approx(0.0)
 
     def test_empty_keywords(self):
-        assert keyword_overlap_score(["python"], []) == 0.0
+        assert keyword_overlap_score(["python"], []) == pytest.approx(0.0)
 
     def test_case_insensitive(self):
         assert keyword_overlap_score(["Python"], ["python"]) == pytest.approx(1.0)

--- a/tests/integration/test_multihop.py
+++ b/tests/integration/test_multihop.py
@@ -188,7 +188,7 @@ def test_typed_path_query_defaults():
     q = TypedPathQuery()
     assert q.start_ids == []
     assert q.path_pattern == []
-    assert q.min_strength == 0.0
+    assert q.min_strength == pytest.approx(0.0)
     assert q.limit == 10
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1397,7 +1397,7 @@ async def test_suggest_links_tool(monkeypatch):
     result = await server.suggest_links(memory_id="mem-1", limit=3)
     assert len(result) == 1
     assert result[0]["target_id"] == "target-1"
-    assert result[0]["score"] == 0.85
+    assert result[0]["score"] == pytest.approx(0.85)
     assert result[0]["memory_type"] == "semantic"
 
 


### PR DESCRIPTION
## Summary
Fixes all 16 SonarCloud reliability bugs that caused the "C Reliability Rating" quality gate failure on PR #35:

- **14x S1244**: Float equality in test assertions → `pytest.approx()`
- **2x S7502**: Unsaved `asyncio.create_task()` → store in `_background_tasks` set with done callback cleanup

## Context
This is the final piece needed to get PR #35 (develop → main) through SonarCloud's quality gate.

## Test plan
- [ ] CI passes
- [ ] SonarCloud quality gate passes (Reliability Rating ≥ A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)